### PR TITLE
Fix env sync and initial CDP command race

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -150,7 +150,7 @@ await session.connect({ profileDir: '/Users/<you>/Library/Application Support/Go
 
 ### Picking a target (tab)
 
-After `connect()`, call `session.use(targetId)` once; subsequent page-level calls (Page/DOM/Runtime/Network/etc.) auto-route to that target's sessionId. `Browser.*` and `Target.*` calls always hit the browser endpoint.
+After `connect()`, the harness automatically attaches one non-internal page target. Call `session.use(targetId)` when you want a specific tab; subsequent page-level calls (Page/DOM/Runtime/Network/etc.) auto-route to that target's sessionId. `Browser.*` and `Target.*` calls always hit the browser endpoint.
 
 ```js
 const tabs = await listPageTargets()                     // no args; uses the connected session
@@ -218,6 +218,7 @@ When attaching to the user's already-running browser:
 
 ## Working with targets (tabs)
 
+- **Default page target.** `session.connect()` attaches the first non-internal page target automatically, creating `about:blank` if needed, so common one-liners can call `session.Page.navigate(...)` immediately after connecting.
 - **Filter Chrome internals.** `listPageTargets()` already drops `chrome://` and `devtools://` URLs. If you call `Target.getTargets()` directly, filter manually.
 - **CDP target order ≠ visible tab-strip order.** When the user says "the first tab I can see", use a screenshot or page title to identify it — `Target.activateTarget` only switches to a known targetId.
 

--- a/sdk/browser-harness-js
+++ b/sdk/browser-harness-js
@@ -79,7 +79,11 @@ is_up() {
 start_repl() {
   is_up && return 0
   ensure_bun || return 1
-  CDP_REPL_PORT="$PORT" nohup bun "$REPL" >"$LOG" 2>&1 &
+  if command -v setsid >/dev/null 2>&1; then
+    CDP_REPL_PORT="$PORT" setsid -f bun "$REPL" >"$LOG" 2>&1 < /dev/null
+  else
+    CDP_REPL_PORT="$PORT" nohup bun "$REPL" >"$LOG" 2>&1 < /dev/null &
+  fi
   for _ in $(seq 1 100); do
     sleep 0.1
     is_up && return 0
@@ -124,7 +128,7 @@ sync_repl_env() {
     code="${code}process.env.${name}='$(js_single_quote "$value")';"
   done
   [ -n "$code" ] || return 0
-  printf '%s' "$code" | curl -fsS --max-time 2 --data-binary @- "$URL/eval" >/dev/null || true
+  printf '%s' "$code" | curl -fsS --max-time 2 --data-binary @- "$URL/eval" >/dev/null 2>&1 || true
 }
 
 case "${1:-}" in

--- a/sdk/browser-harness-js
+++ b/sdk/browser-harness-js
@@ -19,6 +19,18 @@
 
 set -euo pipefail
 
+load_env_file() {
+  local file="$1"
+  [ -r "$file" ] || return 0
+  set -a
+  # shellcheck disable=SC1090
+  . "$file"
+  set +a
+}
+
+load_env_file /etc/bux/env
+load_env_file "$HOME/.claude/browser.env"
+
 PORT="${CDP_REPL_PORT:-9876}"
 HOST="127.0.0.1"
 URL="http://$HOST:$PORT"
@@ -80,7 +92,7 @@ post_eval() {
   # Capture body + status separately. Body goes to stdout (only if non-empty)
   # on 200; otherwise to stderr with non-zero exit.
   local out status body
-  out=$(curl -sS -w '\n___STATUS___%{http_code}' --data-binary "$1" "$URL/eval")
+  out=$(printf '%s' "$1" | curl -sS -w '\n___STATUS___%{http_code}' --data-binary @- "$URL/eval")
   status="${out##*___STATUS___}"
   body="${out%$'\n'___STATUS___*}"
   if [ "$status" = "200" ]; then
@@ -90,6 +102,29 @@ post_eval() {
     [ -n "$body" ] && printf '%s\n' "$body" >&2
     return 1
   fi
+}
+
+js_single_quote() {
+  printf '%s' "$1" | sed -e "s/\\\\/\\\\\\\\/g" -e "s/'/\\\\'/g"
+}
+
+sync_repl_env() {
+  local code="" name value
+  for name in \
+    BROWSER_USE_API_KEY \
+    BUX_PROFILE_ID \
+    BU_PROFILE_ID \
+    BU_BROWSER_ID \
+    BU_CDP_WS \
+    BU_BROWSER_LIVE_URL \
+    BU_BROWSER_EXPIRES_AT
+  do
+    value="${!name:-}"
+    [ -n "$value" ] || continue
+    code="${code}process.env.${name}='$(js_single_quote "$value")';"
+  done
+  [ -n "$code" ] || return 0
+  printf '%s' "$code" | curl -fsS --max-time 2 --data-binary @- "$URL/eval" >/dev/null || true
 }
 
 case "${1:-}" in
@@ -103,6 +138,7 @@ case "${1:-}" in
     ;;
   --start)
     start_repl
+    sync_repl_env
     curl -sS "$URL/health"; echo
     ;;
   --stop)
@@ -117,6 +153,7 @@ case "${1:-}" in
     is_up && curl -s -X POST "$URL/quit" >/dev/null 2>&1 || true
     sleep 0.2
     start_repl
+    sync_repl_env
     curl -sS "$URL/health"; echo
     ;;
   --logs)
@@ -127,11 +164,13 @@ case "${1:-}" in
     ;;
   "")
     start_repl
+    sync_repl_env
     code="$(cat)"
     post_eval "$code"
     ;;
   *)
     start_repl
+    sync_repl_env
     post_eval "$1"
     ;;
 esac

--- a/sdk/repl.ts
+++ b/sdk/repl.ts
@@ -51,6 +51,14 @@ async function runSnippet(code: string): Promise<unknown> {
   return await (0, eval)(wrapped);
 }
 
+let evalQueue: Promise<void> = Promise.resolve();
+
+function enqueueEval<T>(task: () => Promise<T>): Promise<T> {
+  const run = evalQueue.then(task, task);
+  evalQueue = run.then(() => undefined, () => undefined);
+  return run;
+}
+
 const TEXT = { 'content-type': 'text/plain; charset=utf-8' } as const;
 
 /**
@@ -89,7 +97,7 @@ const server = Bun.serve({
         return new Response('empty body\n', { status: 400, headers: TEXT });
       }
       try {
-        const result = await runSnippet(code);
+        const result = await enqueueEval(() => runSnippet(code));
         const body = renderResult(result);
         return new Response(body, { status: 200, headers: TEXT });
       } catch (e: any) {
@@ -114,3 +122,5 @@ console.log(JSON.stringify({
   port: server.port,
   message: `CDP REPL listening on http://127.0.0.1:${server.port}`,
 }));
+
+await new Promise(() => {});

--- a/sdk/session.ts
+++ b/sdk/session.ts
@@ -103,6 +103,7 @@ export class Session implements Transport {
 
   private openWs(wsUrl: string, timeoutMs: number): Promise<void> {
     return new Promise<void>((res, rej) => {
+      this.activeSessionId = undefined;
       const ws = new WebSocket(wsUrl);
       let done = false;
       const finish = (err?: Error) => {
@@ -119,6 +120,10 @@ export class Session implements Transport {
       ws.addEventListener('close', () => {
         for (const [, p] of this.pending) p.reject(new Error('CDP socket closed'));
         this.pending.clear();
+        if (this.ws === ws) {
+          this.ws = undefined;
+          this.activeSessionId = undefined;
+        }
         finish(new Error('WS closed before open (likely 403 or port closed)'));
       });
       this.ws = ws;
@@ -178,10 +183,8 @@ export class Session implements Transport {
   }
 
   // Transport implementation. Called by the generated domain bindings.
-  _call(method: string, params: unknown = {}): Promise<unknown> {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      return Promise.reject(new Error('Not connected. Call session.connect(...) first.'));
-    }
+  async _call(method: string, params: unknown = {}): Promise<unknown> {
+    const ws = await this.ensureOpen();
     const id = this.nextId++;
     const msg: Record<string, unknown> = { id, method, params: params ?? {} };
     if (this.activeSessionId && !isBrowserLevel(method)) {
@@ -189,8 +192,27 @@ export class Session implements Transport {
     }
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.ws!.send(JSON.stringify(msg));
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch (e) {
+        this.pending.delete(id);
+        reject(e);
+      }
     });
+  }
+
+  private async ensureOpen(timeoutMs = 1_000): Promise<WebSocket> {
+    const ws = this.ws;
+    if (!ws) throw new Error('Not connected. Call session.connect(...) first.');
+
+    const deadline = Date.now() + timeoutMs;
+    while (ws.readyState === WebSocket.CONNECTING && Date.now() < deadline) {
+      await Bun.sleep(10);
+    }
+    if (ws.readyState !== WebSocket.OPEN) {
+      throw new Error('Not connected. Call session.connect(...) first.');
+    }
+    return ws;
   }
 
   private onMessage(raw: string): void {
@@ -376,4 +398,3 @@ async function tryReadDevToolsActivePort(
     return undefined;
   }
 }
-

--- a/sdk/session.ts
+++ b/sdk/session.ts
@@ -77,6 +77,7 @@ export class Session implements Transport {
     if (opts.wsUrl || opts.profileDir) {
       const wsUrl = await resolveWsUrl(opts);
       await this.openWs(wsUrl, timeoutMs);
+      await this.useDefaultPageTarget();
       return;
     }
     const browsers = await detectBrowsers();
@@ -90,6 +91,7 @@ export class Session implements Transport {
     for (const b of browsers) {
       try {
         await this.openWs(b.wsUrl, timeoutMs);
+        await this.useDefaultPageTarget();
         return;
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
@@ -146,6 +148,28 @@ export class Session implements Transport {
     const r = await this._call('Target.attachToTarget', { targetId, flatten: true }) as { sessionId: string };
     this.activeSessionId = r.sessionId;
     return r.sessionId;
+  }
+
+  /**
+   * Fresh connections start on Chrome's browser endpoint, but Page/DOM/Runtime
+   * methods only exist on page targets. Attach the first available page target
+   * so common one-liners can call `session.Page.navigate(...)` immediately
+   * after `session.connect(...)`.
+   */
+  private async useDefaultPageTarget(): Promise<void> {
+    const { targetInfos } = await this._call('Target.getTargets', {}) as { targetInfos: PageTarget[] };
+    const page = targetInfos.find(t =>
+      t.type === 'page' &&
+      !t.url.startsWith('chrome://') &&
+      !t.url.startsWith('devtools://')
+    );
+    if (page) {
+      await this.use(page.targetId);
+      return;
+    }
+
+    const created = await this._call('Target.createTarget', { url: 'about:blank' }) as { targetId: string };
+    await this.use(created.targetId);
   }
 
   /** Set the active sessionId directly (e.g. one you already attached). */


### PR DESCRIPTION
## Summary
- auto-load `/etc/bux/env` and `~/.claude/browser.env` with export semantics before starting or calling the REPL
- sync Browser Use / Browser Use Box env vars into an already-running persistent REPL
- wait for the WebSocket to reach `OPEN` before sending the first CDP command, and clear stale target session state on reconnect
- send eval request bodies through stdin so snippets are not treated as curl data options

## Context
This was reproduced while running Browser Use Box against a long-lived Browser Use Cloud browser. The failure mode was intermittent `Not connected. Call session.connect(...) first.` immediately after `await session.connect({wsUrl: process.env.BU_CDP_WS})`, plus missing `process.env.BU_CDP_WS` when the shell had sourced but not exported `browser.env`.

Browser Use Box official page: https://browser-use.com/bux
Browser Use Box project: https://github.com/browser-use/bux
Demo that exposed the issue: https://www.tiktok.com/@browser_use/video/7639824093721758989

## Testing
- `bash -n sdk/browser-harness-js`
- `cd sdk && /home/bux/.bun/bin/bun install --frozen-lockfile && /home/bux/.bun/bin/bun x tsc --noEmit`
- live smoke test against Browser Use Cloud: `await session.connect({wsUrl: process.env.BU_CDP_WS}); return {product:(await session.Browser.getVersion()).product, hasKey:Boolean(process.env.BROWSER_USE_API_KEY), hasWs:Boolean(process.env.BU_CDP_WS)};` returned `Chrome/146.0.7680.71` with both env vars present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make env vars load and sync reliably for the Browser Use harness, fix the initial CDP command race, and auto-attach a default page target so `Page.*` calls work immediately. Also serialize REPL evals and fully detach the REPL to improve stability for long-lived sessions.

- **Bug Fixes**
  - Auto-load `/etc/bux/env` and `~/.claude/browser.env` with export semantics, and sync key vars (`BU_CDP_WS`, `BROWSER_USE_API_KEY`, etc.) into an already-running REPL on start/restart/exec.
  - Serialize REPL evals to prevent overlapping snippet races, and start the REPL detached (`setsid`/`nohup` with stdin closed) so it survives shell exits and avoids terminal coupling.
  - Wait for WebSocket `OPEN` before the first CDP command; clear stale target session state on reconnect; guard sends with `ensureOpen`.
  - Auto-attach the first non-internal page target on connect (create `about:blank` if none) so `session.Page.*` works right away.
  - Pipe eval bodies to `curl` via stdin so code snippets aren’t treated as data/option flags.

<sup>Written for commit fde0e17af5ed1158e9d34de15ca870526704a6c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->