### PR TITLE
Handle ignored CDP command rejections

### DIFF
--- a/sdk/repl.test.ts
+++ b/sdk/repl.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+type ReplStartup = {
+  ok: boolean;
+  ready: boolean;
+  port: number;
+};
+
+async function readStartup(
+  stdout: ReadableStream<Uint8Array>,
+): Promise<ReplStartup> {
+  const reader = stdout.getReader();
+  const decoder = new TextDecoder();
+  let output = '';
+
+  try {
+    while (!output.includes('\n')) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return JSON.parse(output.trim()) as ReplStartup;
+}
+
+describe('persistent REPL', () => {
+  test('survives a detached rejected promise from an evaluated snippet', async () => {
+    const child = Bun.spawn({
+      cmd: [process.execPath, fileURLToPath(new URL('./repl.ts', import.meta.url))],
+      env: { ...process.env, CDP_REPL_PORT: '0' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    try {
+      const startup = await readStartup(child.stdout);
+      expect(startup.ok).toBe(true);
+      expect(startup.ready).toBe(true);
+      expect(startup.port).toBeGreaterThan(0);
+
+      const baseUrl = `http://127.0.0.1:${startup.port}`;
+      const overwrite = await fetch(`${baseUrl}/eval`, {
+        method: 'POST',
+        body: 'globalThis.eval = () => { throw new Error("poisoned evaluator"); }; return "overwritten";',
+      });
+      expect(overwrite.status).toBe(200);
+      expect(await overwrite.text()).toBe('overwritten');
+
+      const afterOverwrite = await fetch(`${baseUrl}/eval`, {
+        method: 'POST',
+        body: '6 * 7',
+      });
+      expect(afterOverwrite.status).toBe(200);
+      expect(await afterOverwrite.text()).toBe('42');
+
+      const detached = await fetch(`${baseUrl}/eval`, {
+        method: 'POST',
+        body: 'void Promise.reject(new Error("detached rejection probe")); return "scheduled";',
+      });
+      expect(detached.status).toBe(200);
+      expect(await detached.text()).toBe('scheduled');
+
+      await Bun.sleep(25);
+
+      const health = await fetch(`${baseUrl}/health`);
+      expect(health.status).toBe(200);
+      expect(await health.json()).toMatchObject({ ok: true });
+
+      const subsequent = await fetch(`${baseUrl}/eval`, {
+        method: 'POST',
+        body: '21 * 2',
+      });
+      expect(subsequent.status).toBe(200);
+      expect(await subsequent.text()).toBe('42');
+      expect(child.exitCode).toBeNull();
+    } finally {
+      child.kill();
+      await child.exited;
+    }
+  });
+});

--- a/sdk/repl.ts
+++ b/sdk/repl.ts
@@ -27,6 +27,16 @@ const session = new Session();
 
 const PORT = Number(process.env.CDP_REPL_PORT ?? 9876);
 const startedAt = Date.now();
+// Snippets run in global scope and may overwrite globalThis.eval. Keep the
+// evaluator itself immutable for the lifetime of this server process.
+const indirectEval: typeof eval = eval;
+
+process.on('unhandledRejection', (reason) => {
+  const message = reason instanceof Error
+    ? reason.stack ?? reason.message
+    : String(reason);
+  console.error(`[browser-harness-js] Detached promise rejected: ${message}`);
+});
 
 function isExpression(code: string): boolean {
   const trimmed = code.trim();
@@ -48,7 +58,7 @@ function serialize(v: unknown): unknown {
 async function runSnippet(code: string): Promise<unknown> {
   const body = isExpression(code) ? `return (${code});` : code;
   const wrapped = `(async () => { ${body} })()`;
-  return await (0, eval)(wrapped);
+  return await indirectEval(wrapped);
 }
 
 const TEXT = { 'content-type': 'text/plain; charset=utf-8' } as const;

--- a/sdk/session.test.ts
+++ b/sdk/session.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Session } from './session.ts';
+
+function connectFakeSocket(session: Session): void {
+  const internals = session as unknown as {
+    ws: { readyState: number; send: (message: string) => void };
+    onMessage: (message: string) => void;
+  };
+  internals.ws = {
+    readyState: WebSocket.OPEN,
+    send(message) {
+      const { id } = JSON.parse(message) as { id: number };
+      queueMicrotask(() => internals.onMessage(JSON.stringify({
+        id,
+        error: { code: -32000, message: 'Fetch domain is not enabled' },
+      })));
+    },
+  };
+}
+
+describe('Session command rejection handling', () => {
+  test('an ignored CDP rejection does not become unhandled', async () => {
+    const session = new Session();
+    connectFakeSocket(session);
+
+    void session._call('Fetch.disable');
+    await Bun.sleep(10);
+  });
+
+  test('an awaited CDP rejection still reaches the caller', async () => {
+    const session = new Session();
+    connectFakeSocket(session);
+
+    await expect(session._call('Fetch.disable')).rejects.toThrow(
+      'CDP -32000: Fetch domain is not enabled',
+    );
+  });
+});

--- a/sdk/session.ts
+++ b/sdk/session.ts
@@ -191,6 +191,9 @@ export class Session implements Transport {
       this.pending.set(id, { resolve, reject });
       this.ws!.send(JSON.stringify(msg));
     });
+    // A snippet may intentionally fire-and-forget a CDP command. Keep an
+    // ignored rejection from terminating Bun while preserving the original
+    // promise's rejection for callers that await it.
     void promise.catch(() => {});
     return promise;
   }

--- a/sdk/session.ts
+++ b/sdk/session.ts
@@ -187,10 +187,12 @@ export class Session implements Transport {
     if (this.activeSessionId && !isBrowserLevel(method)) {
       msg.sessionId = this.activeSessionId;
     }
-    return new Promise((resolve, reject) => {
+    const promise = new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
       this.ws!.send(JSON.stringify(msg));
     });
+    void promise.catch(() => {});
+    return promise;
   }
 
   private onMessage(raw: string): void {


### PR DESCRIPTION
## Summary

- preserve the evaluator even when a snippet overwrites `globalThis.eval`
- keep ignored CDP and arbitrary detached Promise rejections from terminating the persistent Bun process
- preserve normal rejection behavior for callers that await a failing CDP command
- test the real HTTP daemon across evaluator poisoning, detached rejection, `/health`, and a subsequent `/eval`

## Why

Browser Harness is a long-lived control plane. A malformed agent snippet can schedule a Promise that rejects after `/eval` has already returned, or overwrite the global `eval` binding used by later requests. Bun previously terminated or poisoned the daemon in those cases even though Chrome and the CDP endpoint remained healthy.

## Testing

- `bun test`
- live child-process regression: overwrite `globalThis.eval`, trigger a detached rejected Promise, verify `/health`, then verify a later `/eval` returns `42`
- `git diff --check HEAD^ HEAD`
