### PR TITLE
fix: add Windows launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Or paste this into your agent — it'll install the skill, put the CLI on your P
 
 ```text
 Run `npx skills add https://github.com/browser-use/browser-harness-js --skill cdp`, then
-symlink `browser-harness-js` into a directory on my PATH, then use the cdp skill to drive
-my browser: look at all the tabs I have open, group them by topic, and screenshot the most
-interesting one.
+put the skill's `sdk` directory on my PATH, then use the cdp skill to drive my browser:
+look at all the tabs I have open, group them by topic, and screenshot the most interesting
+one. Follow the skill's setup steps for my operating system.
 ```
 
 (The CLI auto-installs [`bun`](https://bun.sh) on first run if it's missing. Set `BROWSER_HARNESS_SKIP_BUN_INSTALL=1` to opt out.)
@@ -45,6 +45,7 @@ See [interaction-skills/](interaction-skills/) for recipes on the mechanics that
 
 - `SKILL.md` — day-to-day usage; how to connect, pick a tab, call methods, persist state
 - `sdk/browser-harness-js` — tiny CLI that auto-spawns the server and forwards snippets
+- `sdk/browser-harness-js.cmd` — Windows launcher that delegates to Git for Windows Bash
 - `sdk/repl.ts` — Bun HTTP server holding one persistent `Session`
 - `sdk/session.ts` — the `Session` class: transport, connect, target routing, events
 - `sdk/gen.ts` — codegen: reads `browser_protocol.json` + `js_protocol.json` → typed wrappers

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,6 +24,23 @@ command -v browser-harness-js >/dev/null || ln -sf <skill-dir>/sdk/browser-harne
 command -v browser-harness-js >/dev/null || { mkdir -p ~/.local/bin && ln -sf <skill-dir>/sdk/browser-harness-js ~/.local/bin/browser-harness-js; }
 ```
 
+On Windows, the bundled `browser-harness-js.cmd` uses Git for Windows Bash to run the
+same CLI. Add the skill's `sdk` directory to the user PATH from PowerShell (replace
+`<skill-dir>` with the real install path):
+
+```powershell
+$cliDir = (Resolve-Path '<skill-dir>\sdk').Path
+[string]$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (($userPath -split ';') -notcontains $cliDir) {
+  [Environment]::SetEnvironmentVariable('Path', ($userPath.TrimEnd(';') + ';' + $cliDir), 'User')
+}
+$env:Path = $env:Path.TrimEnd(';') + ';' + $cliDir
+browser-harness-js --start
+```
+
+Git for Windows is required. If Bash is installed somewhere else, set
+`BROWSER_HARNESS_JS_BASH` to the full path of `bash.exe`.
+
 The CLI auto-installs `bun` on first run if it's missing (the server is Bun-native). Set `BROWSER_HARNESS_SKIP_BUN_INSTALL=1` to opt out.
 
 ## How to use
@@ -243,6 +260,7 @@ browser-harness-js --restart   # pick up the new bindings
 All paths are relative to `<skill-dir>` (the install path — see top of this doc).
 
 - `/usr/local/bin/browser-harness-js` → `<skill-dir>/sdk/browser-harness-js` (the CLI)
+- `sdk/browser-harness-js.cmd` — Windows launcher (the `sdk` directory itself goes on PATH)
 - `sdk/repl.ts` — HTTP server (`Bun.serve` on `127.0.0.1:9876`)
 - `sdk/session.ts` — `Session` class (transport, connect, target routing, events)
 - `sdk/generated.ts` — codegen output: every CDP method as a typed wrapper

--- a/sdk/browser-harness-js.cmd
+++ b/sdk/browser-harness-js.cmd
@@ -1,0 +1,44 @@
+@echo off
+rem browser-harness-js Windows launcher - runs the bundled bash script under
+rem Git for Windows' bash.exe. The script is POSIX-only (curl, nohup, /tmp,
+rem bun bootstrap) so we delegate to bash rather than re-implement in cmd.exe.
+rem
+rem Discovery order:
+rem   1. %BROWSER_HARNESS_JS_BASH% (explicit env override)
+rem   2. %ProgramFiles%\Git\bin\bash.exe
+rem   3. %ProgramFiles(x86)%\Git\bin\bash.exe
+rem   4. %LocalAppData%\Programs\Git\bin\bash.exe   (per-user install)
+rem
+rem Without Git for Windows, exits 1 with a stderr hint so the agent sees a
+rem clean error instead of triggering Windows' "Open with..." association
+rem dialog on the extensionless bash script next to this file.
+
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "BASH_SCRIPT=%SCRIPT_DIR%browser-harness-js"
+
+rem `exit /b` (no arg) propagates the current ERRORLEVEL. Inside a
+rem parenthesized block, `exit /b %errorlevel%` would expand at parse time
+rem and silently report 0 even if bash failed.
+
+if defined BROWSER_HARNESS_JS_BASH (
+  if exist "%BROWSER_HARNESS_JS_BASH%" (
+    "%BROWSER_HARNESS_JS_BASH%" "%BASH_SCRIPT%" %*
+    exit /b
+  )
+)
+
+for %%P in (
+  "%ProgramFiles%\Git\bin\bash.exe"
+  "%ProgramFiles(x86)%\Git\bin\bash.exe"
+  "%LocalAppData%\Programs\Git\bin\bash.exe"
+) do (
+  if exist %%P (
+    %%P "%BASH_SCRIPT%" %*
+    exit /b
+  )
+)
+
+>&2 echo browser-harness-js: bash.exe not found. Install Git for Windows from https://gitforwindows.org/ or set BROWSER_HARNESS_JS_BASH to a bash.exe path.
+exit /b 1


### PR DESCRIPTION
## Summary

- ship a Windows `.cmd` entry point next to the existing Bash CLI
- find Git for Windows Bash in the standard system and per-user locations
- add Windows PATH setup to the skill and make the README install prompt work across operating systems

Fixes #5.

## Checks

- `bun install --frozen-lockfile`
- `bunx tsc --noEmit`
- existing CLI start, eval, status, and stop smoke test
- static checks for Bash discovery, argument forwarding, exit-code propagation, and the missing-Bash error
- compared the launcher with the version already shipped in `browser-use/desktop`

The batch launcher was not executed on Windows in this environment.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Windows launcher so Windows users can run the CLI, which previously required Bash.

- Ships `sdk/browser-harness-js.cmd`, which delegates to Git for Windows Bash and forwards arguments and exit codes.
- Discovers Bash via the `BROWSER_HARNESS_JS_BASH` override, standard system paths, or a per-user install, and prints a clear error when missing.
- Updates the skill and README with Windows PATH setup instructions and adds the `.cmd` file to the file lists.
- Fixes #5.

<sup>Written for commit 4639915f692d93d31af1ce8d232704df08fbe89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness-js/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

