### PR TITLE
fix: route extension commands through browser session

### DIFF
--- a/sdk/session.test.ts
+++ b/sdk/session.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Session } from './session.ts';
+
+async function sentMessage(method: string): Promise<Record<string, unknown>> {
+  const session = new Session();
+  session.setActiveSession('page-session');
+
+  let sent: Record<string, unknown> | undefined;
+  (session as any).ws = {
+    readyState: WebSocket.OPEN,
+    send(raw: string) {
+      sent = JSON.parse(raw);
+      queueMicrotask(() => {
+        (session as any).onMessage(JSON.stringify({ id: sent!.id, result: {} }));
+      });
+    },
+  };
+
+  await session._call(method, {});
+  return sent!;
+}
+
+describe('Session CDP routing', () => {
+  test('keeps page commands on the active target session', async () => {
+    expect(await sentMessage('Page.navigate')).toMatchObject({ sessionId: 'page-session' });
+  });
+
+  test('routes extension commands through the browser session', async () => {
+    expect(await sentMessage('Extensions.getExtensions')).not.toHaveProperty('sessionId');
+  });
+});

--- a/sdk/session.ts
+++ b/sdk/session.ts
@@ -219,7 +219,7 @@ export class CdpError extends Error {
 
 /** Browser-level methods never take a sessionId. */
 function isBrowserLevel(method: string): boolean {
-  return method.startsWith('Browser.') || method.startsWith('Target.');
+  return method.startsWith('Browser.') || method.startsWith('Target.') || method.startsWith('Extensions.');
 }
 
 /**
@@ -376,4 +376,3 @@ async function tryReadDevToolsActivePort(
     return undefined;
   }
 }
-


### PR DESCRIPTION
## Summary

- route `Extensions.*` through the browser session without an active target `sessionId`
- keep target-scoped commands on the active target session

Addresses #4.

`Extensions.*` is browser-level. After `Session.use(targetId)`, these commands were incorrectly receiving the active target `sessionId`, so Chrome returned `CDP -32000: Method not available`.

## Checks

- `bun test`: `keeps page commands on the active target session`
- `bun test`: `routes extension commands through the browser session`
- `bunx tsc --noEmit`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `Extensions.*` CDP commands through the browser session instead of the active target session, fixing the `-32000: Method not available` error when a target is active. Page commands keep using the active target session. Addresses #4.

- Adds tests covering both routing paths.

<sup>Written for commit ba552c4ff41b77fc70fc1a355f35a20cacdd9ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness-js/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

