### PR TITLE
docs: avoid activating tabs by default

### DIFF
--- a/interaction-skills/connection.md
+++ b/interaction-skills/connection.md
@@ -70,8 +70,7 @@ await session.use(targetId)
 1. `await session.connect()` — auto-detect the running browser.
 2. `const tabs = await listPageTargets()` — see what real pages exist.
 3. `await session.use(tabs[0].targetId)` — route Page/DOM/Runtime/Network calls to that target.
-4. `await session.Target.activateTarget({ targetId: tabs[0].targetId })` — bring the tab visually to front.
-5. Enable the domains you need: `await session.Page.enable()`, `await session.Network.enable({})`, etc.
+4. Enable the domains you need: `await session.Page.enable()`, `await session.Network.enable({})`, etc.
 
 ## CDP target order ≠ visible tab-strip order
 
@@ -83,7 +82,7 @@ When the user says "the first tab I can see", do NOT trust the order of `Target.
 
 `Target.activateTarget` only switches to a targetId you already know — it cannot resolve "leftmost tab".
 
-## Bringing Chrome to front
+## Bringing Chrome to front (when needed)
 
 ```bash
 # macOS — prefer AppleScript over `open -a` (reuses current profile, avoids the profile picker)


### PR DESCRIPTION
## Summary

- remove `Target.activateTarget(...)` from the default CDP startup sequence
- clarify that bringing Chrome to the foreground is only needed when requested

## Why

`session.use(targetId)` already attaches to the target and routes page-level CDP commands without changing the visible active tab. When multiple agents follow the current startup sequence, the extra `activateTarget` call makes them repeatedly pull their own tabs to the foreground and fight over Chrome's UI.

`interaction-skills/tabs.md` already documents `session.use` and `Target.activateTarget` as independent operations.

## Checks

- manually verified Runtime/DOM inspection, navigation, screenshots, mouse clicks, and text input on a background target without activating it
- `git diff --check`

Fixes #8.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `Target.activateTarget` from the default CDP startup sequence so concurrent agents stop pulling their own tabs to the foreground and fighting over Chrome's UI. `session.use(targetId)` already attaches to the target and routes page-level CDP commands without switching the visible active tab.

- Renames the 'Bringing Chrome to front' section header to clarify foregrounding is only needed when explicitly requested.
- Fixes #8.

<sup>Written for commit 9716dfd62f13d2e37dc2f32314c8aaa2ba63bf7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-harness-js/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

